### PR TITLE
Removed unnecessary MVC references

### DIFF
--- a/dot-net-core/dotNetCoreRestService/Controllers/TestController.cs
+++ b/dot-net-core/dotNetCoreRestService/Controllers/TestController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace dotNetCoreRestService.Controllers
 {
     [Route("api/[controller]")]
-    public class TestController : Controller
+    public class TestController : ControllerBase
     {
         [HttpGet]
         public string Get()

--- a/dot-net-core/dotNetCoreRestService/Startup.cs
+++ b/dot-net-core/dotNetCoreRestService/Startup.cs
@@ -17,17 +17,12 @@ namespace dotNetCoreRestService
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddMvcCore().AddFormatterMappings().AddJsonFormatters();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-
             app.UseMvc();
         }
     }

--- a/dot-net-core/dotNetCoreRestService/dotNetCoreRestService.csproj
+++ b/dot-net-core/dotNetCoreRestService/dotNetCoreRestService.csproj
@@ -9,11 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.0.2" />
   </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Reference "Microsoft.AspNetCore.All" takes a lot of bloat for MVC specific features that slow down the service overall. I modified it to be a REST-service only.