### PR TITLE
Remove unnecessary 'cargo build' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,6 @@ Main tutorial: https://github.com/iron/router/blob/master/examples/simple.rs
 Run:  
 
 ```bash
-$ cargo build
 $ cargo run --release
 ``` 
 


### PR DESCRIPTION
There is unnecessary `cargo build` in Rust Iron description

`cargo run --release` performs `cargo build --release` if needed, whereas `cargo build` is for development/debug build
